### PR TITLE
Fix landing page JP toggle and add subtitle

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -48,6 +48,7 @@
     >
 
     <h1>ShoCode</h1>
+    <p class="subtitle">Shonan Code Summit</p>
 
     <p class="tagline" lang="en">Agentic Coding on the Coast</p>
     <p class="tagline" lang="ja">海辺のエージェンティック・コーディング</p>

--- a/site/style.css
+++ b/site/style.css
@@ -179,6 +179,13 @@ a:focus-visible {
   font-size: clamp(2.2rem, 5vw, 3.6rem);
   font-weight: 800;
   letter-spacing: -0.02em;
+  margin-bottom: 0.25rem;
+}
+
+.hero .subtitle {
+  font-size: clamp(1rem, 2.0vw, 1.15rem);
+  font-weight: 300;
+  opacity: 0.9;
   margin-bottom: 0.5rem;
 }
 
@@ -469,7 +476,7 @@ section:nth-of-type(even) {
 
 /* ---- Bilingual Content Visibility ---- */
 
-[lang="ja"] {
+[lang="ja"]:not(:root) {
   display: none;
 }
 


### PR DESCRIPTION
## Fixes  - **JP language toggle whiteout:** The CSS rule `[lang="ja"] { display: none }` was matching the `<html>` element when switching to Japanese, hiding the entire page. Fixed with `:not(:root)` selector. - **Added "Shonan Code Summit" subtitle** between the ShoCode heading and the tagline in the hero section.  ## Files changed  - `site/style.css` — Fix `:not(:root)` on lang selector + subtitle style - `site/index.html` — Add subtitle element